### PR TITLE
Fix lon/lat file for genesis day

### DIFF
--- a/StatInterface/GenerateDistributions.py
+++ b/StatInterface/GenerateDistributions.py
@@ -154,6 +154,9 @@ class GenerateDistributions(object):
 
         self.pName = parameterName
 
+        assert len(self.pList) == len(self.lonLat), "Parameter data " +
+               "Lon/Lat data are not the same length."
+
         maxCellNum = stats.maxCellNum(self.gridLimit, self.gridSpace)
 
         # Writing CDF dataset for all individual cell number into files

--- a/StatInterface/GenerateDistributions.py
+++ b/StatInterface/GenerateDistributions.py
@@ -154,8 +154,12 @@ class GenerateDistributions(object):
 
         self.pName = parameterName
 
-        assert len(self.pList) == len(self.lonLat), "Parameter data " +
-               "Lon/Lat data are not the same length."
+        if len(self.pList) != len(self.lonLat):
+            errmsg = ("Parameter data and "
+                      "Lon/Lat data are not the same length "
+                      "for {}.".format(parameterName))
+            self.logger.critical(errmsg)
+            raise IndexError(errmsg)
 
         maxCellNum = stats.maxCellNum(self.gridLimit, self.gridSpace)
 

--- a/StatInterface/StatInterface.py
+++ b/StatInterface/StatInterface.py
@@ -113,7 +113,7 @@ class StatInterface(object):
         log.debug('Reading data from %s',
                   pjoin(self.processPath, 'jdays'))
         pList = pjoin(self.processPath, 'jdays')
-        lonLat = pjoin(self.processPath, 'init_lon_lat')
+        lonLat = pjoin(self.processPath, 'origin_lon_lat')
         kde = KDEParameters.KDEParameters(self.kdeType)
         #kde.generateGenesisDateCDF(jdays, lonLat, bw=14,
         #                           genesisKDE=pjoin(self.processPath,


### PR DESCRIPTION
I noticed that the lon/lat file used in the genesis day calc is inconsistent with the jdays file. The first excluded storms with 1 observation while the later included. This pull request includes a fix, and a new check to confirm no other parameters have this issue.