### PR TITLE
Update processMultipliers to use single layer

### DIFF
--- a/ProcessMultipliers/processMultipliers.py
+++ b/ProcessMultipliers/processMultipliers.py
@@ -266,7 +266,9 @@ class getMultipliers():
         yMinWM = gt[3] + widthWM * gt[4] + heightWM * gt[5]
         xMaxWM = gt[0] + widthWM * gt[1] + heightWM * gt[2]
         yMaxWM = gt[3]
-        log.info('Extent from wind multiplier image : {{\'xMin\': {0}, \'xMax\': {1}, \'yMin\': {2}, \'yMax\': {3} }}'.format(xMinWM, xMaxWM, yMinWM, yMaxWM))
+        log.info('Extent from wind multiplier image : '
+                 '{{\'xMin\': {0}, \'xMax\': {1}, \'yMin\': {2}, \'yMax\': {3} }}'
+                 .format(xMinWM, xMaxWM, yMinWM, yMaxWM))
         del ds
 
         # Take only intersecting extent of provided extent and wind multiplier image extent

--- a/ProcessMultipliers/processMultipliers.py
+++ b/ProcessMultipliers/processMultipliers.py
@@ -235,13 +235,13 @@ class getMultipliers():
             BandWriteArray(bandOut, dataOut.data)
 
     def computeOutputExtentIfInvalid(self, gust_file, computed_wm_path):
-        '''
+        """
         If 'Extent' property is not valid, output image extent is computed from regional wind
         data (gust file) and wind multiplier image extents.
 
         :param str gust_file: file path of regional wind data / gust file
         :param str computed_wm_path: file path of wind multiplier image
-        '''
+        """
         if 'xMin' in self.extent and 'xMax' in self.extent and 'yMin' in self.extent and 'yMax' in self.extent:
             return
 
@@ -277,14 +277,14 @@ class getMultipliers():
         log.info('Applying effective extent {0}'.format(self.extent))
 
     def extractDirections(self, dirns, output_path):
-        '''
+        """
         Create Geotiffs for wind multiplier (terrain, topographic and shielding combined) into
         a single Geotiff from 8-band source file by applying specified extent.
         Output files are named "m4_" direction.
 
         :param str dirns: list of eight ordinal directions for wind
         :param str output_path: path to the output directory
-        '''
+        """
         band_index = 1
         log.info('Multipliers will be written to {0}'.format(output_path))
         for dirn in dirns:

--- a/ProcessMultipliers/processMultipliers.py
+++ b/ProcessMultipliers/processMultipliers.py
@@ -252,7 +252,7 @@ class getMultipliers():
         log.info('Multipliers will be written to {0}'.format(working_dir))
         for dirn in dirns:
             log.info('working on %s', dirn)
-            os.system('gdal_translate -a_srs EPSG:4326 -of GTiff -co COMPRESS=LZW -projwin '
+            os.system('gdal_translate -a_srs EPSG:4326 -of GTiff -projwin '
                       '{0} {1} {2} {3} -b {4} "{5}" {6}m4_{7}.tif'
                       .format(self.Extent['xMin'], self.Extent['yMin'], self.Extent['xMax'], self.Extent['yMax'],
                               band_index, self.ComputedWMPath, working_dir, dirn))
@@ -473,7 +473,7 @@ def reprojectDataset(src_file, match_filename, dst_filename,
 
     # Output / destination
     drv = gdal.GetDriverByName('GTiff')
-    dst = drv.Create(dst_filename, wide, high, 1, gdal.GDT_Float32, options=['COMPRESS=LZW'])
+    dst = drv.Create(dst_filename, wide, high, 1, gdal.GDT_Float32)
     dst.SetGeoTransform(match_geotrans)
     dst.SetProjection(match_proj)
     dstBand = dst.GetRasterBand(1)
@@ -587,7 +587,7 @@ def processMult(wspd, uu, vv, lon, lat, working_dir, m4_max_file = 'm4_ne.tif'):
     # multipliers
     drv = gdal.GetDriverByName("GTiff")
     dst_ds = drv.Create(output_file, cols, rows, 1,
-                        gdal.GDT_Float32, ['BIGTIFF=NO', 'SPARSE_OK=TRUE', 'COMPRESS=LZW'])
+                        gdal.GDT_Float32, ['BIGTIFF=NO', 'SPARSE_OK=TRUE'])
     dst_ds.SetGeoTransform(wind_geot)
     dst_ds.SetProjection(wind_proj)
     dst_band = dst_ds.GetRasterBand(1)

--- a/ProcessMultipliers/processMultipliers.py
+++ b/ProcessMultipliers/processMultipliers.py
@@ -236,7 +236,7 @@ class getMultipliers():
             bandOut.SetNoDataValue(-9999)
             BandWriteArray(bandOut, dataOut.data)
 
-    def extractDirections(self, dirns, working_dir):
+    def extractDirections(self, dirns, output_path):
         '''
         Create Geotiffs for wind multiplier (terrain, topographic and shielding combined) into
         a single Geotiff from 8-band source file by applying specified extent.
@@ -249,13 +249,13 @@ class getMultipliers():
         log.debug('Read VRT file data')
         band_index = 1
 
-        log.info('Multipliers will be written to {0}'.format(working_dir))
+        log.info('Multipliers will be written to {0}'.format(output_path))
         for dirn in dirns:
             log.info('working on %s', dirn)
             os.system('gdal_translate -a_srs EPSG:4326 -of GTiff -projwin '
                       '{0} {1} {2} {3} -b {4} "{5}" {6}m4_{7}.tif'
                       .format(self.Extent['xMin'], self.Extent['yMin'], self.Extent['xMax'], self.Extent['yMax'],
-                              band_index, self.ComputedWMPath, working_dir, dirn))
+                              band_index, self.ComputedWMPath, output_path, dirn))
             band_index += 1
 
 def generate_syn_mult_img(tl_x, tl_y, delta, dir_path, shape,

--- a/tests/test_processMultipliers.py
+++ b/tests/test_processMultipliers.py
@@ -250,6 +250,36 @@ class TestProcessMultipliers(unittest.TestCase):
 
         shutil.rmtree(dir_path)
 
+    def test_computeOutputExtentIfInvalid(self):
+        """Test createRaster returns a gdal dataset"""
+
+        # Write a .nc file to test with dummy data. This is the gust file
+        f_nc = tempfile.NamedTemporaryFile(suffix='.nc', prefix='test_processMultipliers', delete=False)
+        gust_file = f_nc.name
+        f_nc.close()
+
+        ncfile = Dataset(gust_file, mode='w', format='NETCDF3_CLASSIC')
+        lat_dim = ncfile.createDimension('lat', 2)
+        lon_dim = ncfile.createDimension('lon', 2)
+        lat = ncfile.createVariable('lat', np.float32, ('lat',))
+        lon = ncfile.createVariable('lon', np.float32, ('lon',))
+        lon[:] = [121, 129]
+        lat[:] = [10, 17]
+        ncfile.close()
+
+        # Test when correct extent provided in config
+        config_extent = dict(xMin=20, xMax=21, yMin=20, yMax=21)
+        pM.extent = pM.computeOutputExtentIfInvalid(config_extent, gust_file, self.reprojectRaster)
+        self.assertEqual(pM.extent, config_extent)
+
+        # Test when extent provided in config
+        config_extent = dict()
+        pM.extent = pM.computeOutputExtentIfInvalid(config_extent, gust_file, self.testRasterFile)
+        self.assertEqual(pM.extent['xMin'], 121)
+        self.assertEqual(pM.extent['xMax'], 129)
+        self.assertEqual(pM.extent['yMin'], 10)
+        self.assertEqual(pM.extent['yMax'], 17)
+
     @unittest.skip("Not working")
     def test_xprocessMult_A(self):
         dir_path = tempfile.mkdtemp(prefix='test_processMult')


### PR DESCRIPTION
https://github.com/GeoscienceAustralia/tcrm/issues/92
https://gajira.atlassian.net/browse/TCRM-78
Added new properties “Multipliers“and “Extent” in Configuration file. Computed wind multiplier data  is specified by “Multipliers“ property which is used instad of three separate layers (Mh, Mz and Ms). “Extent” specifies the longitude and latitude range in {'xMin':<val>, 'xMax':<val>,'yMin':<val>, 'yMax':<val>} format to produce output image. Applied default value calculation for “Extent” property from regional wind data (gust file) and wind multiplier image extents.