### PR TITLE
Tcrm 126 run error

### DIFF
--- a/ProcessMultipliers/processMultipliers.py
+++ b/ProcessMultipliers/processMultipliers.py
@@ -73,7 +73,6 @@ import numpy.ma as ma
 
 from osgeo import osr, gdal, gdalconst
 from osgeo.gdal_array import BandReadAsArray, CopyDatasetInfo, BandWriteArray
-from gdal import *
 
 from netCDF4 import Dataset
 

--- a/README.rst
+++ b/README.rst
@@ -79,8 +79,8 @@ Status
     :target: https://landscape.io/github/GeoscienceAustralia/tcrm/develop
     :alt: Code Health
     
-.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.3741493.svg
-   :target: https://doi.org/10.5281/zenodo.3741493
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.4070660.svg
+   :target: https://doi.org/10.5281/zenodo.4070660
 
 Screenshot
 ==========


### PR DESCRIPTION
Usage "from gdal import *" is deprecated and removed in osgeo/GDAL 3.2.0. Import already done in line 74