### PR TITLE
Bugfix for ACF function

### DIFF
--- a/.github/workflows/tcrm-tests.yml
+++ b/.github/workflows/tcrm-tests.yml
@@ -13,7 +13,7 @@ jobs:
   TCRM:
     name: Test TCRM
     runs-on: ubuntu-latest
-    strategy: 
+    strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]
     steps:
@@ -24,12 +24,13 @@ jobs:
         python-version: ${{ matrix.python-version }}
         mamba-version: "*"
         channels: conda-forge,defaults
+        channel-priority: true
         activate-environment: tcrm
         environment-file: tcrmenv.yml
         auto-activate-base: false
 
     - name: Test with pytest
-      env: 
+      env:
         PYTHONPATH: ~/tcrm;~/tcrm/Utilities
       shell: bash -l {0}
       run: |

--- a/.github/workflows/tcrm-tests.yml
+++ b/.github/workflows/tcrm-tests.yml
@@ -28,6 +28,7 @@ jobs:
         activate-environment: tcrm
         environment-file: tcrmenv.yml
         auto-activate-base: false
+        use-only-tar-bz2: true
 
     - name: Test with pytest
       env:

--- a/ProcessMultipliers/processMultipliers.py
+++ b/ProcessMultipliers/processMultipliers.py
@@ -72,9 +72,9 @@ import boto3
 import numpy as np
 import numpy.ma as ma
 from botocore.exceptions import ClientError
-from netCDF4 import Dataset
 from osgeo import osr, gdal, gdalconst
 from osgeo.gdal_array import BandReadAsArray, CopyDatasetInfo, BandWriteArray
+from netCDF4 import Dataset
 
 from Utilities import pathLocator
 from Utilities.AsyncRun import AsyncRun

--- a/StatInterface/generateStats.py
+++ b/StatInterface/generateStats.py
@@ -16,6 +16,7 @@ import logging
 import sys
 
 import numpy as np
+import statsmodels.api as sm
 
 import Utilities.stats as stats
 
@@ -32,12 +33,9 @@ def acf(p, nlags=1):
     :type p: 1-d :class:`numpy.ndarray`
 
     """
-    ar = np.array([1]+[np.corrcoef(p[:-i], p[i:])[0,1] for i in range(1, nlags + 1)])
-    #ar = np.correlate(p, p, 'full')
-    #n = len(p)
-    ## Grab only the lag-one autocorrelation coeff.
-    #ar = ar[n-1:(n+nlags)]/ar.max()
-    return ar
+
+    acorr = sm.tsa.acf(p, nlags=nlags)
+    return acorr
 
 
 class parameters(object):
@@ -242,11 +240,6 @@ class GenerateStats:
             sig = np.std(p)
 
         # Calculate the autocorrelations:
-        alphas = np.correlate(p, p, 'full')
-        n = len(p)
-
-        # Grab only the lag-one autocorrelation coeff.
-        alpha = alphas[n]/alphas.max()
         alpha = acf(p)[-1]
         phi = np.sqrt(1 - alpha**2)
         mn = min(p)

--- a/TrackGenerator/TrackGenerator.py
+++ b/TrackGenerator/TrackGenerator.py
@@ -418,7 +418,7 @@ class TrackGenerator(object):
 
         log.debug('Loading cell statistics for speed from netcdf file')
         self.vStats = init('all_speed')
-        self.vStats.load(pjoin(self.processPath, 'speed_stats.nc'))
+        self.vStats.load(pjoin(self.processPath, 'speed_rate_stats.nc'))
 
         log.debug('Loading cell statistics for pressure from netcdf file')
         self.pStats = init('all_pressure')
@@ -426,7 +426,7 @@ class TrackGenerator(object):
 
         log.debug('Loading cell statistics for bearing from netcdf file')
         self.bStats = init('all_bearing', angular=True)
-        self.bStats.load(pjoin(self.processPath, 'bearing_stats.nc'))
+        self.bStats.load(pjoin(self.processPath, 'bearing_rate_stats.nc'))
 
         log.debug('Loading cell statistics for pressure_rate from netcdf file')
         self.dpStats = init('pressure_rate')
@@ -1141,7 +1141,7 @@ class TrackGenerator(object):
         if i == 1:
             self.theta += math.degrees(sigma[c] * self.bChi)
         else:
-            self.theta = math.degrees(mu[c] + sigma[c] * self.bChi)
+            self.theta += math.degrees(mu[c] + sigma[c] * self.bChi)
 
         self.theta = np.mod(self.theta, 360.)
 
@@ -1185,7 +1185,7 @@ class TrackGenerator(object):
         if i == 1:
             self.v += abs(sigma[c] * self.vChi)
         else:
-            self.v = abs(mu[c] + sigma[c] * self.vChi)
+            self.v += (mu[c] + sigma[c] * self.vChi)
 
     def _stepSizeChange(self, c, i, onLand):
         """

--- a/tcrmenv.yml
+++ b/tcrmenv.yml
@@ -2,8 +2,9 @@ name: tcrm
 channels:
   - defaults
   - conda-forge
-  - gdal-master
 dependencies:
+  - gdal
+  - libgdal
   - pip
   - numpy
   - scipy
@@ -21,8 +22,6 @@ dependencies:
   - simplejson
   - sqlite
   - statsmodels
-  - libgdal
-  - gdal
   - configparser
   - cartopy>=0.18.0
   - affine

--- a/tcrmenv.yml
+++ b/tcrmenv.yml
@@ -2,6 +2,7 @@ name: tcrm
 channels:
   - defaults
   - conda-forge
+  - gdal-master
 dependencies:
   - pip
   - numpy

--- a/tests/test_SamplingOrigin.py
+++ b/tests/test_SamplingOrigin.py
@@ -28,7 +28,7 @@
 import os, sys
 import pickle
 import unittest
-from scipy import random
+from numpy import random
 from tests import NumpyTestCase
 try:
     from . import pathLocate

--- a/tests/test_SamplingParameters.py
+++ b/tests/test_SamplingParameters.py
@@ -28,7 +28,7 @@
 import os, sys
 import pickle
 import unittest
-from scipy import random
+from numpy import random
 from tests import NumpyTestCase
 try:
     from . import pathLocate

--- a/tests/test_generateStats.py
+++ b/tests/test_generateStats.py
@@ -75,13 +75,13 @@ class TestGenerateStats(NumpyTestCase.NumpyTestCase):
         self.numpyAssertAlmostEqual(coeffs_sig_sample, coeffs_sig_test)
 
         coeffs_alpha_sample = wP.coeffs.alpha[0:10]
-        coeffs_alpha_test = numpy.array([0.51818004, 0.55450803, 0.66634809, 0.61266186, 0.61266186,
-                                         0.63192755, 0.70984709, 0.64836016, 0.69168147, 0.70101634])
+        coeffs_alpha_test = numpy.array([0.51389973, 0.55107082, 0.65703153, 0.60663585, 0.60663585,
+                                         0.62594031, 0.70423342, 0.64339172, 0.6870522 , 0.69641318])
         self.numpyAssertAlmostEqual(coeffs_alpha_sample, coeffs_alpha_test)
 
         coeffs_phi_sample = wP.coeffs.phi[0:10]
-        coeffs_phi_test = numpy.array([0.85527156, 0.83217838, 0.74564081, 0.79034514, 0.79034514,
-                                       0.77502747, 0.70435581, 0.76133376, 0.7222027 , 0.71314521])
+        coeffs_phi_test = numpy.array([0.85785026, 0.83445848, 0.7538631 , 0.79497984, 0.79497984,
+                                       0.77987097, 0.70996851, 0.76553713, 0.72660806, 0.71764105])
         self.numpyAssertAlmostEqual(coeffs_phi_sample, coeffs_phi_test)
 
         coeffs_min_sample = wP.coeffs.min[0:20]

--- a/tests/test_maps.py
+++ b/tests/test_maps.py
@@ -55,8 +55,8 @@ class TestSelectColorMap(NumpyTestCase.NumpyTestCase):
         self.assertEqual(actual.N, expected.N)
         self.assertEqual(actual.name, expected.name)
         for k in list(actual._segmentdata.keys()):
-            self.numpyAssertAlmostEqual(actual._segmentdata[k],
-                                        expected._segmentdata[k])
+            self.numpyAssertAlmostEqual(np.array(actual._segmentdata[k]),
+                                        np.array(expected._segmentdata[k]))
 
     def setUp(self):
         import seaborn as sns


### PR DESCRIPTION
Updates the autocorrelation function. Now uses `statsmodels.api.tsa.acf()` to calculate acf values.

Fixes an issue where tracks were highly complex and turning back on themselves a lot.  